### PR TITLE
Fix syntax for newer MP4Box version

### DIFF
--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -327,7 +327,7 @@ EOF
   mkvextract chapters -s "${input}" > chapters.list
   
   ### MUX MP4
-  mp4string=("$ionc MP4Box -add BL_RPU.hevc:dv-profile=$dv_target")
+  mp4string=("$ionc MP4Box -add BL_RPU.hevc:dv-profile=$dv_target.hdr10")
   tcount=2
   while read i;do
     stream=`echo "$i" | cut -f1 -d\|`


### PR DESCRIPTION
1.0.1 doesn't build with FFmpeg 5.x and higher. I ran into this issue on Debian 12, which means it will only continue to be an issue going forward. Newer MP4Box versions expect the user to specify backwards compatibility for HDR10 now. I was able to get the latest git version working by hardcoding `.hdr10` to the end of mp4string. This could theoretically be its own variable, but this is what works for me with UHD Blu-ray rips. As always, suggested changes are encouraged and appreciated!

-SugaryHull